### PR TITLE
Supervise OneDHCPD.Server directly

### DIFF
--- a/lib/vintage_net_direct.ex
+++ b/lib/vintage_net_direct.ex
@@ -87,7 +87,7 @@ defmodule VintageNetDirect do
       type: __MODULE__,
       source_config: normalized_config,
       child_specs: [
-        one_dhcpd_child_spec(ifname)
+        {OneDHCPD.Server, [ifname, []]}
       ]
     }
     |> IPv4Config.add_config(ipv4_config, opts)
@@ -112,12 +112,5 @@ defmodule VintageNetDirect do
     else
       {:error, "Can't find #{path}"}
     end
-  end
-
-  defp one_dhcpd_child_spec(ifname) do
-    %{
-      id: {OneDHCPD, ifname},
-      start: {OneDHCPD, :start_server, [ifname]}
-    }
   end
 end

--- a/test/gadget_compatibility_test.exs
+++ b/test/gadget_compatibility_test.exs
@@ -36,7 +36,7 @@ defmodule GadgetCompatibilityTest do
       type: VintageNetDirect,
       source_config: normalized_input,
       child_specs: [
-        %{id: {OneDHCPD, "usb0"}, start: {OneDHCPD, :start_server, ["usb0"]}},
+        {OneDHCPD.Server, ["usb0", []]},
         {VintageNet.Interface.LANConnectivityChecker, "usb0"}
       ],
       down_cmds: [

--- a/test/vintage_net_direct_test.exs
+++ b/test/vintage_net_direct_test.exs
@@ -31,7 +31,7 @@ defmodule VintageNetDirectTest do
       type: VintageNetDirect,
       source_config: input,
       child_specs: [
-        %{id: {OneDHCPD, "usb0"}, start: {OneDHCPD, :start_server, ["usb0"]}},
+        {OneDHCPD.Server, ["usb0", []]},
         {VintageNet.Interface.LANConnectivityChecker, "usb0"}
       ],
       down_cmds: [


### PR DESCRIPTION
This fixes an issue where `vintage_net` would fail to start a
`vintage_net_direct` interface when restoring its configuration due to
the OneDHCPD app not being started. Treating OneDHCPD as a library like
this fixes that issue.

This also has another benefit: Having the OneDHCPD.Server GenServer in
the VintageNet interface's supervision tree makes it easier to thinking
about what happens on failures on both OneDHCPD and VintageNetDirect.